### PR TITLE
change args order to fix leveldb path error

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,12 @@ function errorHandler( name ){
 
 function createReadStream( config ){
 
-  var flags = [ util.format( '-tags=%s', config.tags ), config.file ];
+  var flags = [];
+  flags.push( util.format( '-tags=%s', config.tags ) );
   if( config.hasOwnProperty( 'leveldb' ) ){
     flags.push( util.format( '-leveldb=%s', config.leveldb ) );
   }
+  flags.push( config.file );
 
   var proc = child.spawn( exec, flags );
 


### PR DESCRIPTION
Fix for leveldb path not being correctly passed to the Go script.

Changes argv ordering from:
```
[ '-tags=amenity', '/media/hdd/somes.osm.pbf', '-leveldb=/tmp' ]
```

to...

```
[ '-tags=amenity', '-leveldb=/tmp', '/media/hdd/somes.osm.pbf' ]
```