### PR TITLE
add support for feature values

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If you would like to compile a version of this lib for an architecture which isn
 
 ```bash
 go get;
-go build osm2pbf.go;
+go build pbf2json.go;
 chmod +x pbf2json;
 mv pbf2json build/pbf2json.{platform}-{arch};
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ You can also combine the above 2 delimiters to get even more control over what g
 -tags="highway+name,waterway+name"
 ```
 
+If you need to target only specific values for a tag you can specify exactly which values you wish to extract using the `:` symbol:
+
+```bash
+# only extract amenity tags which have the value of toilets or kindergarten
+-tags="amenity:toilets,amenity:kindergarten"
+```
+
 ### Denormalization
 
 When processing the ways, the node refs are looked up for you and the lat/lon values are added to each way:

--- a/pbf2json.go
+++ b/pbf2json.go
@@ -27,7 +27,13 @@ func getSettings() Settings {
   leveldbPath := flag.String("leveldb", "/tmp", "path to leveldb directory")
   tagList := flag.String("tags", "", "comma-separated list of valid tags, group AND conditions with a +")
   // parseAddresses := flag.Bool("addresses", false, "import addresses true/false")
+
   flag.Parse()
+  args := flag.Args();
+
+  if len( args ) < 1 {
+    log.Fatal("invalid args, you must specify a PBF file")
+  }
 
   // invalid tags
   if( len(*tagList) < 1 ){
@@ -43,7 +49,7 @@ func getSettings() Settings {
   // fmt.Print(conditions, len(conditions))
   // os.Exit(1)
 
-  return Settings{ flag.Args()[0], *leveldbPath, conditions }
+  return Settings{ args[0], *leveldbPath, conditions }
 }
 
 func main() {
@@ -239,11 +245,23 @@ func openLevelDB(path string) *leveldb.DB {
 
 func matchTagsAgainstCompulsoryTagList(tags map[string]string, tagList []string) bool {
   for _, name := range tagList {
-    _, found := tags[name]
-    if !found {
+
+    feature := strings.Split(name,":")
+    foundVal, foundKey := tags[feature[0]]
+
+    // key check
+    if !foundKey {
       return false
     }
+
+    // value check
+    if len( feature ) > 1 {
+      if foundVal != feature[1] {
+        return false
+      }
+    }
   }
+
   return true
 }
 


### PR DESCRIPTION
add support for feature values

this allows more fine-grained targeting of features such as `amenity:toilets,amenity:kindergarten` rather than having to extract all `amenity` values.