### PR TITLE
change value delim to $

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you need to target only specific values for a tag you can specify exactly whi
 
 ```bash
 # only extract amenity tags which have the value of toilets or kindergarten
--tags="amenity:toilets,amenity:kindergarten"
+-tags="amenity$toilets,amenity$kindergarten"
 ```
 
 ### Denormalization

--- a/pbf2json.go
+++ b/pbf2json.go
@@ -254,7 +254,7 @@ func openLevelDB(path string) *leveldb.DB {
 func matchTagsAgainstCompulsoryTagList(tags map[string]string, tagList []string) bool {
   for _, name := range tagList {
 
-    feature := strings.Split(name,":")
+    feature := strings.Split(name,"$")
     foundVal, foundKey := tags[feature[0]]
 
     // key check


### PR DESCRIPTION
follow on from https://github.com/pelias/pbf2json/pull/12, need to change the value delimiter from `:` to `$` so it doesn't conflict with any of the keys currently listed on taginfo (such as `addr:street` or `name:de`)