### PR TITLE
Require Node.js 4.0 or greater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 0.12
   - 4
   - 5
   - 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
 matrix:
   fast_finish: true
   allow_failures:
-    - node_js: 6
 env:
   global:
     - CXX=g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - 4
-  - 5
   - 6
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "Golang osm pbf parser with npm wrapper",
   "homepage": "https://github.com/pelias/pbf2json",
   "license": "MIT",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "scripts": {
     "units": "node test/run.js | tap-spec",
     "test": "npm run units",


### PR DESCRIPTION
This also removes Node.js 5 from TravisCI

Connects pelias/pelias#404