### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ jobs:
     - stage: release
       node_js: 10
       script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
-      if: branch = master
+      if: (branch = master) AND ( type = push )

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 6
   - 8
   - 10
 matrix:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/pelias/pbf2json/issues"
   },
   "engines": {
-    "node": ">=6.0.0",
+    "node": ">=8.0.0",
     "npm": ">=1.4.3"
   },
   "dependencies": {


### PR DESCRIPTION
- Drop support for Node.js  6
- Only run semantic-release on the master branch