### PR TITLE
Improve tag generation

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,7 @@
   "node": true,
   "curly": true,
   "eqeqeq": true,
+  "esversion": 6,
   "freeze": true,
   "immed": true,
   "indent": 2,
@@ -14,8 +15,8 @@
   "plusplus": false,
   "quotmark": "single",
   "undef": true,
-  "unused": true,
+  "unused": false,
   "maxparams": 4,
   "maxdepth": 4,
-  "maxlen": 120
+  "maxlen": 140
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var util = require('util'),
     split = require('split'),
     through = require('through2'),
     child = require('child_process'),
-    exec = path.join(__dirname, 'build', util.format( 'pbf2json.%s-%s', os.platform(), os.arch() ) );
+    exec = path.join(__dirname, 'build', util.format( 'pbf2json.%s-%s', os.platform(), os.arch() ) ),
+    generateParams = require('./lib/generateParams');
 
 // custom log levels can be detected for lines with the format:
 // [level] message
@@ -29,14 +30,9 @@ function errorHandler( name, level ){
 
 function createReadStream( config ){
 
-  var flags = [];
-  flags.push( util.format( '-tags=%s', config.tags ) );
-  if( config.hasOwnProperty( 'leveldb' ) ){
-    flags.push( util.format( '-leveldb=%s', config.leveldb ) );
-  }
-  flags.push( config.file );
+  const params = generateParams(config);
 
-  var proc = child.spawn( exec, flags );
+  var proc = child.spawn( exec, params );
 
   // propagate signals from parent to child
   process.on('SIGINT',  function(){ proc.kill(); });

--- a/lib/generateParams.js
+++ b/lib/generateParams.js
@@ -3,7 +3,10 @@ const util = require('util');
 function generateParams(config) {
   const flags = [];
 
-  flags.push( util.format( '-tags=%s', config.tags ) );
+  if (config.tags) {
+    const tags = config.tags.join(',');
+    flags.push( util.format( '-tags=%s', tags ) );
+  }
   if( config.hasOwnProperty( 'leveldb' ) ){
     flags.push( util.format( '-leveldb=%s', config.leveldb ) );
   }

--- a/lib/generateParams.js
+++ b/lib/generateParams.js
@@ -1,15 +1,14 @@
-const util = require('util');
-
 function generateParams(config) {
   const flags = [];
 
   if (config.tags) {
     const tags = config.tags.join(',');
-    flags.push( util.format( '-tags=%s', tags ) );
+    flags.push( `-tags=${tags}` );
   }
   if( config.hasOwnProperty( 'leveldb' ) ){
-    flags.push( util.format( '-leveldb=%s', config.leveldb ) );
+    flags.push( `-leveldb=${config.leveldb}` );
   }
+
   flags.push( config.file );
 
   return flags;

--- a/lib/generateParams.js
+++ b/lib/generateParams.js
@@ -1,0 +1,15 @@
+const util = require('util');
+
+function generateParams(config) {
+  const flags = [];
+
+  flags.push( util.format( '-tags=%s', config.tags ) );
+  if( config.hasOwnProperty( 'leveldb' ) ){
+    flags.push( util.format( '-leveldb=%s', config.leveldb ) );
+  }
+  flags.push( config.file );
+
+  return flags;
+}
+
+module.exports = generateParams;

--- a/test/lib/generateParams.js
+++ b/test/lib/generateParams.js
@@ -1,0 +1,43 @@
+const generateParams = require('../../lib/generateParams');
+
+module.exports.tests = {};
+
+module.exports.tests.params = function(test) {
+  test('PBF file', function(t) {
+    const config = {
+      file: '/some/path/to/osm.pbf'
+    };
+
+    const params = generateParams(config);
+
+    t.equal(params[params.length - 1], '/some/path/to/osm.pbf', 'final parameter is path to PBF file');
+    t.end();
+  });
+  test('PBF file', function(t) {
+    const config = {
+      tags: [
+        'tag:one',
+        'tag:two',
+        'combination~tags'
+      ]
+    };
+
+    const params = generateParams(config);
+
+    const expected = '-tags=tag:one,tag:two,combination~tags';
+
+    t.equal(params[0], expected, 'tag array is serialized into parameter');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('generateParams: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/run.js
+++ b/test/run.js
@@ -3,7 +3,8 @@ var tape = require('tape');
 var common = {};
 
 var tests = [
-  require('./index.js')
+  require('./index.js'),
+  require('./lib/generateParams.js')
 ];
 
 tests.map(function(t) {


### PR DESCRIPTION
The method we used to calculate the `-tags=...` parameter to pass to the `pbf2json` go executable was brittle, and relied on `util.format`'s handling of arrays, which happened to change in Node.js 12.

This PR extracts that logic to a separate function, adds tests, and ensures the behavior will be more stable over time.

Some cleanup work was required as well, for example an updated `.jshintrc` file to support ES6 syntax.

Connects https://github.com/pelias/pelias/issues/800