### PR TITLE
feat(Node.js): Add Node.js 12 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ notifications:
 node_js:
   - 8
   - 10
+  - 12
 matrix:
   fast_finish: true
 script: npm run travis
@@ -16,6 +17,6 @@ branches:
 jobs:
   include:
     - stage: release
-      node_js: 10
+      node_js: 12
       script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
       if: (branch = master) AND ( type = push )


### PR DESCRIPTION
Node.js 12 (and especially Node.js 12.9) is supposed to be significantly
faster than previous versions, especially when it comes to parsing JSON, which
is often a bottleneck for Pelias importers.

https://nodejs.org/en/blog/release/v12.9.0/
https://v8.dev/blog/v8-release-76

Connects https://github.com/pelias/pelias/issues/800