### PR TITLE
Add waynodes to generateParams.js

### DIFF
--- a/lib/generateParams.js
+++ b/lib/generateParams.js
@@ -8,6 +8,9 @@ function generateParams(config) {
   if( config.hasOwnProperty( 'leveldb' ) ){
     flags.push( `-leveldb=${config.leveldb}` );
   }
+  if( config.hasOwnProperty( 'waynodes' ) ){
+    flags.push( `-waynodes=${config.waynodes}` );
+  }
 
   flags.push( config.file );
 

--- a/lib/generateParams.js
+++ b/lib/generateParams.js
@@ -9,7 +9,7 @@ function generateParams(config) {
     flags.push( `-leveldb=${config.leveldb}` );
   }
   if( config.hasOwnProperty( 'waynodes' ) ){
-    flags.push( `-waynodes=${config.waynodes}` );
+    flags.push( `--waynodes=${config.waynodes}` );
   }
 
   flags.push( config.file );

--- a/test/lib/generateParams.js
+++ b/test/lib/generateParams.js
@@ -29,6 +29,19 @@ module.exports.tests.params = function(test) {
     t.equal(params[0], expected, 'tag array is serialized into parameter');
     t.end();
   });
+
+  test('waynodes', function(t) {
+    const config = {
+      waynodes: true
+    };
+
+    const params = generateParams(config);
+
+    const expected = '--waynodes=true';
+
+    t.equal(params[0], expected, 'waynodes is serialized into parameter');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
From this PR https://github.com/pelias/pbf2json/pull/69 the npm package for this doesn't allow users to pass in
```
config = {
waynodes: true
}
```
to get passed in as  the flag `--waynodes=true`.

Possible to merge and create a new npm version @pelias?

Thanks