### PR TITLE
preallocate buffers when decoding/encoding way nodes

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -71,6 +71,41 @@ func TestEncodingAndDecodingIdsToBytes(t *testing.T) {
 	assert.Equal(t, decoded, ids)
 }
 
+func BenchmarkBytesToLatLon(b *testing.B) {
+	node := &osmpbf.Node{
+		ID:  123,
+		Lat: 12.1234,
+		Lon: -122.1234,
+		Tags: map[string]string{
+			"entrance": "main",
+		},
+	}
+	_, data := nodeToBytes(node)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		bytesToLatLon(data)
+	}
+}
+
+func BenchmarkNodeToBytes(b *testing.B) {
+	node := &osmpbf.Node{
+		ID:  123,
+		Lat: 12.1234,
+		Lon: -122.1234,
+		Tags: map[string]string{
+			"entrance": "main",
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		nodeToBytes(node)
+	}
+}
+
 func BenchmarkIdSliceToBytes(b *testing.B) {
 	ids := make([]int64, 100)
 

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -70,3 +70,24 @@ func TestEncodingAndDecodingIdsToBytes(t *testing.T) {
 	var decoded = bytesToIDSlice(encoded)
 	assert.Equal(t, decoded, ids)
 }
+
+func BenchmarkIdSliceToBytes(b *testing.B) {
+	ids := make([]int64, 100)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		idSliceToBytes(ids)
+	}
+}
+
+func BenchmarkBytesToIDSlice(b *testing.B) {
+	ids := make([]int64, 100)
+	data := idSliceToBytes(ids)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		bytesToIDSlice(data)
+	}
+}

--- a/pbf2json.go
+++ b/pbf2json.go
@@ -609,23 +609,21 @@ func nodeToBytes(node *osmpbf.Node) (string, []byte) {
 }
 
 func idSliceToBytes(ids []int64) []byte {
-	var bufval bytes.Buffer
-	for _, id := range ids {
-		var idBytes = make([]byte, 8)
-		binary.BigEndian.PutUint64(idBytes, uint64(id))
-		bufval.Write(idBytes)
+	buf := make([]byte, 8*len(ids))
+	for i, id := range ids {
+		binary.BigEndian.PutUint64(buf[8*i:], uint64(id))
 	}
-	return bufval.Bytes()
+	return buf
 }
 
 func bytesToIDSlice(bytes []byte) []int64 {
-	var ids []int64
 	if len(bytes)%8 != 0 {
 		log.Fatal("invalid byte slice length: not divisible by 8")
-		return make([]int64, 0)
 	}
-	for i := 0; i < len(bytes)/8; i++ {
-		ids = append(ids, int64(binary.BigEndian.Uint64(bytes[i*8:(i*8)+8])))
+
+	ids := make([]int64, 0, len(bytes)/8)
+	for i := 0; i < len(bytes); i += 8 {
+		ids = append(ids, int64(binary.BigEndian.Uint64(bytes[i:])))
 	}
 	return ids
 }

--- a/pbf2json.go
+++ b/pbf2json.go
@@ -548,16 +548,18 @@ func cacheLookupWayNodes(db *leveldb.DB, wayid int64) ([]map[string]string, erro
 
 // decode bytes to a 'latlon' type object
 func bytesToLatLon(data []byte) map[string]string {
-	buf := make([]byte, 0, 8)
+	buf := make([]byte, 8)
 	latlon := make(map[string]string, 4)
 
 	// first 6 bytes are the latitude
-	buf = append(buf, data[0:6]...)
+	// buf = append(buf, data[0:6]...)
+	copy(buf, data[:6])
 	lat64 := math.Float64frombits(binary.BigEndian.Uint64(buf[:8]))
 	latlon["lat"] = strconv.FormatFloat(lat64, 'f', 7, 64)
 
 	// next 6 bytes are the longitude
-	buf = append(buf[:0], data[6:12]...)
+	// buf = append(buf[:0], data[6:12]...)
+	copy(buf, data[6:12])
 	lon64 := math.Float64frombits(binary.BigEndian.Uint64(buf[:8]))
 	latlon["lon"] = strconv.FormatFloat(lon64, 'f', 7, 64)
 
@@ -611,9 +613,9 @@ func bytesToIDSlice(bytes []byte) []int64 {
 		log.Fatal("invalid byte slice length: not divisible by 8")
 	}
 
-	ids := make([]int64, 0, len(bytes)/8)
-	for i := 0; i < len(bytes); i += 8 {
-		ids = append(ids, int64(binary.BigEndian.Uint64(bytes[i:])))
+	ids := make([]int64, len(bytes)/8)
+	for i := 0; i < len(bytes)/8; i++ {
+		ids[i] = int64(binary.BigEndian.Uint64(bytes[8*i:]))
 	}
 	return ids
 }


### PR DESCRIPTION
#### Here's the reason for this change :rocket:
The `idSliceToBytes` and `bytesToIDSlice` in `pbf2json.go` do not preallocate their buffers causing a performance hit to these functions.  There are few other similar places that could be updated if changes like this are okay.

---
#### Here's what actually got changed :clap:
- [x] updated `idSliceToBytes` to preallocate the bytes buffer
- [x] updated `bytesToIDSlice` to preallocate the ids buffer
- [x] cleaned `bytesToLatLon` for a minor speed improvement
- [x] cleaned up `nodeToBytes` to preallocate and reuse the buffer
- [x] wrote some benchmarks to show the speed improvement

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkBytesToLatLon-12      809           753           -6.92%
BenchmarkNodeToBytes-12        84.5          58.0          -31.36%
BenchmarkIdSliceToBytes-12     1068          232           -78.28%
BenchmarkBytesToIDSlice-12     579           252           -56.48%

benchmark                      old allocs     new allocs     delta
BenchmarkBytesToLatLon-12      8              6              -25.00%
BenchmarkNodeToBytes-12        2              2              +0.00%
BenchmarkIdSliceToBytes-12     5              1              -80.00%
BenchmarkBytesToIDSlice-12     8              1              -87.50%

benchmark                      old bytes     new bytes     delta
BenchmarkBytesToLatLon-12      448           432           -3.57%
BenchmarkNodeToBytes-12        67            19            -71.64%
BenchmarkIdSliceToBytes-12     2224          896           -59.71%
BenchmarkBytesToIDSlice-12     2040          896           -56.08%
```

---
#### Here's how others can test the changes :eyes:
There are existing tests that cover the two impacted functions.