### PR TITLE
disable compiling in GH Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,8 +21,6 @@ jobs:
           go-version: '${{ matrix.go-version }}'
       - name: Run Go unit tests
         run: go test ./...
-      - name: Build binaries
-        run: ./compile.sh
       - name: 'Install node.js ${{ matrix.node-version }}'
         uses: actions/setup-node@v2-beta
         with:
@@ -43,8 +41,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.16.x'
-      - name: Build binaries
-        run: ./compile.sh
       - name: 'Install node.js 16.x'
         uses: actions/setup-node@v2-beta
         with:


### PR DESCRIPTION
there seems to be an issue with running the 'compile' command within the CI env which doesn't exist outside.

the linux 64 binary present in the latest `npm` release produces a `SEGFAULT`:

```bash
./pbf2json.linux-x64 Segmentation fault
```

..however dowloading the binary with the same name from the repo (which was produced locally from the `git commit` hook) works perfectly.

I suspect it's due to running `upx` within a container, or the version of `upx`, so this PR disables building the binaries within the CI env.