### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,7 +34,7 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: 'Install Golang 1.16.x'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "end-to-end": "npm run pretest; node test/end-to-end.js;",
     "lint": "jshint .",
     "validate": "npm ls",
-    "travis": "npm test && npm run end-to-end",
     "compile": "./compile.sh",
     "no-unstaged": "git diff --exit-code"
   },


### PR DESCRIPTION
This repository is one of very few that's a bit different than our standard GitHub Actions config, since it needs to build go modules.

It doesn't need much in terms of updating, just updating all the jobs to use Ubuntu 20. I also removed a lingering reference to TravisCI.