### PR TITLE
CI updates: Modern Node.js versions, action version updates, standard(-ish) template

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '${{ matrix.node-version }}'
       - name: 'Install Golang ${{ matrix.go-version }}'
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '${{ matrix.go-version }}'
       - name: Run Go unit tests

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,0 +1,30 @@
+name: Unit Tests
+on: workflow_call
+jobs:
+  unit-tests:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os:
+          - ubuntu-22.04
+        node-version: [ 18.x, 20.x, 22.x ]
+        go-version:
+        - 1.16.x
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Install node.js ${{ matrix.node-version }}'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '${{ matrix.node-version }}'
+      - name: 'Install Golang ${{ matrix.go-version }}'
+        uses: actions/setup-go@v2
+        with:
+          go-version: '${{ matrix.go-version }}'
+      - name: Run Go unit tests
+        run: go test ./...
+      - name: Install npm dependencies
+        run: npm install
+      - name: Run JS unit tests
+        run: npm test
+      - name: Run JS end-to-end tests
+        run: npm run end-to-end

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,7 @@
+name: Continuous Integration
+on: pull_request
+jobs:
+  unit-tests:
+    # only run this job for forks
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    uses: ./.github/workflows/_test.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
         node-version:
           - 12.x
           - 14.x
@@ -34,7 +34,7 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: 'Install Golang 1.16.x'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,9 +8,6 @@ jobs:
         os:
           - ubuntu-22.04
         node-version:
-          - 12.x
-          - 14.x
-          - 16.x
         go-version:
           - 1.16.x
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version:
+        node-version: [ 18.x, 20.x, 22.x ]
         go-version:
           - 1.16.x
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
         go-version:
           - 1.16.x
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: 'Install Golang ${{ matrix.go-version }}'
         uses: actions/setup-go@v2
         with:
@@ -22,7 +22,7 @@ jobs:
       - name: Run Go unit tests
         run: go test ./...
       - name: 'Install node.js ${{ matrix.node-version }}'
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v4
         with:
           node-version: '${{ matrix.node-version }}'
       - name: Install npm dependencies
@@ -36,13 +36,13 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: 'Install Golang 1.16.x'
         uses: actions/setup-go@v2
         with:
           go-version: '1.16.x'
       - name: 'Install node.js 16.x'
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v4
         with:
           node-version: '16.x'
       - name: Install npm dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,48 +2,17 @@ name: Continuous Integration
 on: push
 jobs:
   unit-tests:
-    runs-on: '${{ matrix.os }}'
-    strategy:
-      matrix:
-        os:
-          - ubuntu-22.04
-        node-version: [ 18.x, 20.x, 22.x ]
-        go-version:
-          - 1.16.x
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'Install Golang ${{ matrix.go-version }}'
-        uses: actions/setup-go@v2
-        with:
-          go-version: '${{ matrix.go-version }}'
-      - name: Run Go unit tests
-        run: go test ./...
-      - name: 'Install node.js ${{ matrix.node-version }}'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '${{ matrix.node-version }}'
-      - name: Install npm dependencies
-        run: npm install
-      - name: Run JS unit tests
-        run: npm test
-      - name: Run JS end-to-end tests
-        run: npm run end-to-end
+    uses: ./.github/workflows/_test.yml
   npm-publish:
     needs: unit-tests
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: 'Install Golang 1.16.x'
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.16.x'
-      - name: 'Install node.js 16.x'
+      - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
-      - name: Install npm dependencies
-        run: npm install
+          node-version: 20.x
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}
@@ -52,3 +21,17 @@ jobs:
           if [[ -n "$GH_TOKEN" && -n "$NPM_TOKEN" ]]; then
             curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
           fi
+  build-docker-images:
+    # run this job if the unit tests passed and the npm-publish job was a success or was skipped
+    # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
+    if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
+    needs: [unit-tests, npm-publish]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker images
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          curl "https://raw.githubusercontent.com/pelias/ci-tools/master/build-docker-images.sh" | bash -


### PR DESCRIPTION
This PR includes a bunch of commits made by a script that standardizes as much as possible our CI config across all repositories.

First and foremost, it ensures we test all Node.js versions that are an LTS release, not EOL, and currently work with this repository.

Also, the CI OS version is now hardcoded to ubuntu-22.04. We fooled around with an organization wide CI variable to configure that, but it broke CI in forks and doesn't really help us much, so it's now undone.

The `pbf2json` repo is a bit of a special snowflake because it requires Go to be installed. While other repos could just us an exact copy of a standard template, I've manually updated the Actions workflows here to be as similar as possible: they're split into pull request and push workflows that share a common unit test file. But that common file does the Go install as needed. I updated the `setup-go` action to `v5`, since internally that updates its own Node.js version, avoiding warnings during CI.

Note: The `v5` setup-go action seems fairly new, and I noticed [this concerning issue report](https://github.com/actions/setup-go/issues/519). Doesn't seem to affect us yet, or could be user error, but we should keep an eye out.

Connects https://github.com/pelias/pelias/issues/950
Connects https://github.com/pelias/pelias/issues/951