### PR TITLE
add support for metadata

### DIFF
--- a/lib/generateParams.js
+++ b/lib/generateParams.js
@@ -11,6 +11,9 @@ function generateParams(config) {
   if( config.hasOwnProperty( 'waynodes' ) ){
     flags.push( `--waynodes=${config.waynodes}` );
   }
+  if( config.metadata ) {
+    flags.push( `--metadata` );
+  }
 
   flags.push( config.file );
 

--- a/pbf2json.go
+++ b/pbf2json.go
@@ -24,6 +24,7 @@ type settings struct {
 	Tags       map[string][]string
 	BatchSize  int
 	WayNodes   bool
+	Metadata   bool
 }
 
 var emptyLatLons = make([]map[string]string, 0)
@@ -35,6 +36,7 @@ func getSettings() settings {
 	tagList := flag.String("tags", "", "comma-separated list of valid tags, group AND conditions with a +")
 	batchSize := flag.Int("batch", 50000, "batch leveldb writes in batches of this size")
 	wayNodes := flag.Bool("waynodes", false, "should the lat/lons of nodes belonging to ways be printed")
+	metadata := flag.Bool("metadata", false, "output metadata such as changset and timestamp")
 
 	flag.Parse()
 	args := flag.Args()
@@ -57,7 +59,7 @@ func getSettings() settings {
 	// fmt.Print(conditions, len(conditions))
 	// os.Exit(1)
 
-	return settings{args[0], *leveldbPath, conditions, *batchSize, *wayNodes}
+	return settings{args[0], *leveldbPath, conditions, *batchSize, *wayNodes, *metadata}
 }
 
 func main() {
@@ -236,7 +238,7 @@ func print(d *osmpbf.Decoder, masks *BitmaskMap, db *leveldb.DB, config settings
 
 					// trim tags
 					v.Tags = trimTags(v.Tags)
-					onNode(v)
+					onNode(v, &config)
 				}
 
 			case *osmpbf.Way:
@@ -285,9 +287,9 @@ func print(d *osmpbf.Decoder, masks *BitmaskMap, db *leveldb.DB, config settings
 					v.Tags = trimTags(v.Tags)
 
 					if config.WayNodes {
-						onWay(v, latlons, centroid, bounds)
+						onWay(v, &config, latlons, centroid, bounds)
 					} else {
-						onWay(v, emptyLatLons, centroid, bounds)
+						onWay(v, &config, emptyLatLons, centroid, bounds)
 					}
 				}
 
@@ -371,7 +373,7 @@ func print(d *osmpbf.Decoder, masks *BitmaskMap, db *leveldb.DB, config settings
 					v.Tags = trimTags(v.Tags)
 
 					// print relation
-					onRelation(v, centroid, bounds)
+					onRelation(v, &config, centroid, bounds)
 				}
 
 			default:
@@ -405,16 +407,43 @@ func findMemberWayLatLons(db *leveldb.DB, v *osmpbf.Relation) [][]map[string]str
 	return memberWayLatLons
 }
 
-type jsonNode struct {
-	ID   int64             `json:"id"`
-	Type string            `json:"type"`
-	Lat  float64           `json:"lat"`
-	Lon  float64           `json:"lon"`
-	Tags map[string]string `json:"tags"`
+type jsonMetadata struct {
+	Version   int32 `json:"version,omitempty"`
+	Timestamp int64 `json:"timestamp,omitempty"`
+	User      string `json:"user,omitempty"`
+	Changeset int64 `json:"changeset,omitempty"`
 }
 
-func onNode(node *osmpbf.Node) {
-	marshall := jsonNode{node.ID, "node", node.Lat, node.Lon, node.Tags}
+func formatMetadata(info osmpbf.Info, config *settings) *jsonMetadata {
+	if config.Metadata != true {
+		return nil
+	}
+	return &jsonMetadata{
+		Version:   info.Version,
+		Timestamp: info.Timestamp.Unix(),
+		User: info.User,
+		Changeset: info.Changeset,
+	}
+}
+
+type jsonNode struct {
+	ID       int64             `json:"id"`
+	Type     string            `json:"type"`
+	Lat      float64           `json:"lat"`
+	Lon      float64           `json:"lon"`
+	Tags     map[string]string `json:"tags"`
+	Metadata *jsonMetadata     `json:"meta,omitempty"`
+}
+
+func onNode(node *osmpbf.Node, config *settings) {
+	marshall := jsonNode{
+		ID:       node.ID,
+		Type:     "node",
+		Lat:      node.Lat,
+		Lon:      node.Lon,
+		Tags:     node.Tags,
+		Metadata: formatMetadata(node.Info, config),
+	}
 	json, _ := json.Marshal(marshall)
 	fmt.Println(string(json))
 }
@@ -427,6 +456,7 @@ type jsonWay struct {
 	Centroid map[string]string   `json:"centroid"`
 	Bounds   map[string]string   `json:"bounds"`
 	Nodes    []map[string]string `json:"nodes,omitempty"`
+	Metadata *jsonMetadata       `json:"meta,omitempty"`
 }
 
 func jsonBbox(bounds *geo.Bound) map[string]string {
@@ -440,9 +470,18 @@ func jsonBbox(bounds *geo.Bound) map[string]string {
 	return bbox
 }
 
-func onWay(way *osmpbf.Way, latlons []map[string]string, centroid map[string]string, bounds *geo.Bound) {
+func onWay(way *osmpbf.Way, config *settings, latlons []map[string]string, centroid map[string]string, bounds *geo.Bound) {
 	bbox := jsonBbox(bounds)
-	marshall := jsonWay{way.ID, "way", way.Tags /*, way.NodeIDs*/, centroid, bbox, latlons}
+	marshall := jsonWay{
+		ID:   way.ID,
+		Type: "way",
+		Tags: way.Tags,
+		/*, way.NodeIDs,*/
+		Centroid: centroid,
+		Bounds:   bbox,
+		Nodes:    latlons,
+		Metadata: formatMetadata(way.Info, config),
+	}
 	json, _ := json.Marshal(marshall)
 	fmt.Println(string(json))
 }
@@ -453,11 +492,19 @@ type jsonRelation struct {
 	Tags     map[string]string `json:"tags"`
 	Centroid map[string]string `json:"centroid"`
 	Bounds   map[string]string `json:"bounds"`
+	Metadata *jsonMetadata     `json:"meta,omitempty"`
 }
 
-func onRelation(relation *osmpbf.Relation, centroid map[string]string, bounds *geo.Bound) {
+func onRelation(relation *osmpbf.Relation, config *settings, centroid map[string]string, bounds *geo.Bound) {
 	bbox := jsonBbox(bounds)
-	marshall := jsonRelation{relation.ID, "relation", relation.Tags, centroid, bbox}
+	marshall := jsonRelation{
+		ID:       relation.ID,
+		Type:     "relation",
+		Tags:     relation.Tags,
+		Centroid: centroid,
+		Bounds:   bbox,
+		Metadata: formatMetadata(relation.Info, config),
+	}
 	json, _ := json.Marshal(marshall)
 	fmt.Println(string(json))
 }

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -23,7 +23,9 @@ function test( name, tags, cb ){
   fs.writeFileSync( tmpfile, '{}' ); // init naivedb
   var db = naivedb(tmpfile);
 
-  pbf2json.createReadStream({ file: pbfPath, tags: tags })
+  const metadata = name === "metadata"; // just for one test case
+
+  pbf2json.createReadStream({ file: pbfPath, tags: tags, metadata })
     .pipe( through.obj( function( obj, _, next ){
       obj.gid = obj.type + ':' + obj.id;
       next(null, obj);
@@ -51,6 +53,7 @@ function test( name, tags, cb ){
 }
 
 var tests = [
+  [ 'metadata',   ['shop~musical_instrument'] ],
   [ 'single',     ['building'] ],
   [ 'multiple',   ['building','shop'] ],
   [ 'colon',      ['addr:housenumber'] ],

--- a/test/fixtures/metadata.json
+++ b/test/fixtures/metadata.json
@@ -1,0 +1,58 @@
+{
+  "node:946073131": {
+    "id": 946073131,
+    "type": "node",
+    "lat": 49.2716963,
+    "lon": -123.13586950000001,
+    "tags": {
+      "name": "Geza Burghardt Luthiery",
+      "opening_hours": "Mo,we,fr 3pm-6pm",
+      "phone": "6046831135",
+      "shop": "musical_instrument"
+    },
+    "meta": {
+      "version": 4,
+      "timestamp": 1418526780,
+      "user": "AmateurCartographer",
+      "changeset": 27449665
+    },
+    "gid": "node:946073131"
+  },
+  "node:1104197676": {
+    "id": 1104197676,
+    "type": "node",
+    "lat": 49.264455600000005,
+    "lon": -123.1839819,
+    "tags": {
+      "name": "Prussin Music",
+      "shop": "musical_instrument"
+    },
+    "meta": {
+      "version": 1,
+      "timestamp": 1295060940,
+      "user": "pnorman",
+      "changeset": 6973466
+    },
+    "gid": "node:1104197676"
+  },
+  "node:1240309412": {
+    "id": 1240309412,
+    "type": "node",
+    "lat": 49.263236000000006,
+    "lon": -123.186035,
+    "tags": {
+      "addr:housenumber": "2621",
+      "addr:street": "Alma Street",
+      "name": "Rufus Guitar Shop",
+      "phone": "6042221717",
+      "shop": "musical_instrument"
+    },
+    "meta": {
+      "version": 2,
+      "timestamp": 1388605829,
+      "user": "Math1985",
+      "changeset": 19751536
+    },
+    "gid": "node:1240309412"
+  }
+}


### PR DESCRIPTION
hi, i see that this repository is active again, so I'd like to raise a PR for the changes that we made in our fork a few years ago. It would be nice to get this merged into the official package :)


---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

It's useful to have access to the metadata inside the pbf file. For example, when building QA tools for OSM.

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

This is based on #81, which is 5 years out of date. The main changes are:
- added all metadata fields, not just `Timestamp` and `Version`
- added test cases
- rebased onto `master`

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->

* end-to-end tests in this repository
* end-to-end tests in a tool that imports this library: https://github.com/osm-nz/linz-address-import/commit/c64fc9b34ffa1d5884a302e9f8b4aea9864880c9
* by manually editing `package.json` to point to this branch ([example](https://github.com/osm-nz/linz-address-import/blob/4f30acc68e50b2cb5cf4188fa13600479fed93e3/package.json#L35))

Superseeds / Closes #81