### PR TITLE
Drop Nodejs 18, add Node.js 24 to CI

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [ 18.x, 20.x, 22.x ]
+        node-version: [ 20.x, 22.x ]
         go-version:
         - 1.16.x
     steps:

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [ 20.x, 22.x ]
+        node-version: [ 20.x, 22.x, 24.x ]
         go-version:
         - 1.16.x
     steps:


### PR DESCRIPTION
This drops a now EOL Node.js version from our CI, and adds the latest version, Node.js 24, to CI.

Connects https://github.com/pelias/pelias/issues/985