### PR TITLE
Improve end to end tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gotest": "go test ./...",
     "test": "npm run units",
     "pretest": "test/pretest.sh",
-    "end-to-end": "npm run pretest; node test/end-to-end.js;",
+    "end-to-end": "npm run pretest && node test/end-to-end.js",
     "lint": "jshint .",
     "validate": "npm ls",
     "compile": "./compile.sh",

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -17,13 +17,16 @@ var fs = require('fs'),
 function test( name, tags, cb ){
 
   var tmpfile = tmp.fileSync({ postfix: '.json' }).name,
+      leveldbDir = tmp.dirSync({ unsafeCleanup: true }),
       pbfPath = path.resolve(__dirname) + '/vancouver_canada.osm.pbf',
       expectedPath = path.resolve(__dirname) + '/fixtures/' + name + '.json';
 
   fs.writeFileSync( tmpfile, '{}' ); // init naivedb
   var db = naivedb(tmpfile);
 
-  pbf2json.createReadStream({ file: pbfPath, tags: tags })
+  // give each test its own leveldb directory, the default of '/tmp' is shared
+  // between concurrent runs and leaves its files behind
+  pbf2json.createReadStream({ file: pbfPath, tags: tags, leveldb: leveldbDir.name })
     .pipe( through.obj( function( obj, _, next ){
       obj.gid = obj.type + ':' + obj.id;
       next(null, obj);
@@ -33,6 +36,7 @@ function test( name, tags, cb ){
 
       // write actual to disk
       db.writeSync();
+      leveldbDir.removeCallback();
 
       // load files from disk
       var actual = JSON.parse( fs.readFileSync( tmpfile, { encoding: 'utf8' } ) ),


### PR DESCRIPTION
Two small fixes for the end to end tests in this repo:

First, use a unique tmpdir for every run. Without this, two simultaneous runs can clobber each others files, runs across different users can create permission errors, etc.

Second, require the `pretest` npm command to succeed before running the end to end test script itself. Without this, compile and other errors aren't caught, and the e2e test script itself can fail in strange ways.