### PR TITLE
Improve and reduce duplication in compile script

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,77 +1,98 @@
 #!/bin/bash
 
-# note: you will need to follow the guide here to install the tools required
-# to cross-compile for different architectures on your host machine.
+# Cross-compiles the Go binaries shipped in the npm package.
+#
+# Called with no arguments it builds every supported target, which is what the
+# 'prepack' lifecycle script does when the package is published. Pass 'native'
+# (or explicit target names) to build a subset, eg. './compile.sh native'.
+#
+# note: to cross-compile on your own machine you may need to follow the guide at
 # http://dave.cheney.net/2015/08/22/cross-compilation-with-go-1-5
 
-# ensure the compiler exits with status 0
-function assert() {
-  if [[ $1 != 0 ]]; then
-    echo "one or more architectures failed to compile"
-    exit $1;
-  fi
+set -o pipefail
+
+# 'go' is not always on the PATH in CI, fall back to the runner tool cache
+if ! command -v go &> /dev/null; then
+  for candidate in "${RUNNER_TOOL_CACHE}"/go/*/x64/bin /usr/local/go/bin; do
+    if [[ -x "${candidate}/go" ]]; then
+      export PATH="${candidate}:${PATH}"
+      break
+    fi
+  done
+fi
+
+if ! command -v go &> /dev/null; then
+  echo "the go compiler is required to build pbf2json" >&2
+  exit 1
+fi
+
+# target name -> GOOS GOARCH 'expected file(1) output' use_upx
+declare -A TARGETS=(
+  ['linux-x64']="linux amd64 'ELF 64-bit LSB.*x86-64' yes"
+  ['linux-arm64']="linux arm64 'ELF 64-bit LSB.*aarch64' yes"
+  ['darwin-x64']="darwin amd64 'Mach-O 64-bit.*x86_64' no"
+  ['darwin-arm64']="darwin arm64 'Mach-O 64-bit.*arm64' no"
+  # UPX is disabled on darwin due to https://github.com/upx/upx/issues/187
+  ['win32-x64']="windows amd64 'PE32\+ executable.*x86-64' yes"
+)
+
+# the target matching the machine we're running on
+function native_target() {
+  local goos goarch
+  goos=$(go env GOOS)
+  goarch=$(go env GOARCH)
+  [[ "${goos}" == 'windows' ]] && goos='win32'
+  [[ "${goarch}" == 'amd64' ]] && goarch='x64'
+  echo "${goos}-${goarch}"
 }
 
-# check the reported file class matches what's expected
-function check() {
-  actual=$(file -b ${1});
-  if [[ "${actual}" != "${2}"* ]]; then
-    echo "invalid file architecture: ${1}"
-    echo "expected: ${2}"
-    echo "actual: ${actual}"
-    echo "-${actual}-${2}-"
+function build() {
+  local name="$1"
+  if [[ -z "${TARGETS[$name]}" ]]; then
+    echo "unknown compile target: ${name}" >&2
     exit 1
   fi
+
+  local goos goarch expected upx
+  eval "set -- ${TARGETS[$name]}"
+  goos="$1"; goarch="$2"; expected="$3"; upx="$4"
+
+  local out="build/pbf2json.${name}"
+
+  echo "[compile] ${name}";
+  env GOOS="${goos}" GOARCH="${goarch}" go build -ldflags="-s -w" \
+    -gcflags=-trimpath="${GOPATH}" -asmflags=-trimpath="${GOPATH}" -o "${out}"
+  if [[ $? != 0 ]]; then
+    echo "failed to compile ${name}" >&2
+    exit 1
+  fi
+  chmod +x "${out}"
+
+  # confirm the binary is actually for the architecture we asked for
+  local actual
+  actual=$(file -b "${out}")
+  if ! grep -qE "${expected}" <<< "${actual}"; then
+    echo "invalid file architecture: ${out}" >&2
+    echo "expected: ${expected}" >&2
+    echo "actual: ${actual}" >&2
+    exit 1
+  fi
+
+  # if the 'UPX' binary packer is available, use it https://upx.github.io/
+  if [[ "${upx}" == 'yes' ]] && command -v upx &> /dev/null; then
+    upx "${out}"
+  fi
 }
 
-# if the 'UPX' bindary packer is available, use it
-# https://upx.github.io/
-function compress() {
-  [ -x "$(command -v upx)" ] && upx "${1}"
-}
+targets=("$@")
+if [[ ${#targets[@]} == 0 ]]; then
+  targets=("${!TARGETS[@]}")
+  rm -rf build # a full build starts from scratch, partial builds do not
+elif [[ "${targets[0]}" == 'native' ]]; then
+  targets=("$(native_target)")
+fi
 
-# ensure build directory exists
-rm -rf build; mkdir -p build
-
-echo "[compile] linux arm64";
-env GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -gcflags=-trimpath="${GOPATH}" -asmflags=-trimpath="${GOPATH}";
-assert $?;
-chmod +x pbf2json;
-mv pbf2json build/pbf2json.linux-arm64;
-check 'build/pbf2json.linux-arm64' 'ELF 64-bit LSB executable';
-compress 'build/pbf2json.linux-arm64';
-
-echo "[compile] linux x64";
-env GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -gcflags=-trimpath="${GOPATH}" -asmflags=-trimpath="${GOPATH}";
-assert $?;
-chmod +x pbf2json;
-mv pbf2json build/pbf2json.linux-x64;
-check 'build/pbf2json.linux-x64' 'ELF 64-bit LSB executable';
-compress 'build/pbf2json.linux-x64';
-
-echo "[compile] darwin x64";
-env GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -gcflags=-trimpath="${GOPATH}" -asmflags=-trimpath="${GOPATH}";
-assert $?;
-chmod +x pbf2json;
-mv pbf2json build/pbf2json.darwin-x64;
-check 'build/pbf2json.darwin-x64' 'Mach-O 64-bit';
-# UPX disabled due to https://github.com/upx/upx/issues/187
-# compress 'build/pbf2json.darwin-x64';
-
-echo "[compile] darwin arm64";
-env GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -gcflags=-trimpath="${GOPATH}" -asmflags=-trimpath="${GOPATH}";
-assert $?;
-chmod +x pbf2json;
-mv pbf2json build/pbf2json.darwin-arm64;
-check 'build/pbf2json.darwin-arm64' 'Mach-O 64-bit';
-# UPX disabled due to https://github.com/upx/upx/issues/187
-# note: this is untested, assumed to be the same bug as above
-# compress 'build/pbf2json.darwin-arm64';
-
-echo "[compile] windows x64";
-env GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -gcflags=-trimpath=${GOPATH} -asmflags=-trimpath=${GOPATH} -o pbf2json.exe;
-assert $?;
-chmod +x pbf2json.exe;
-mv pbf2json.exe build/pbf2json.win32-x64;
-check 'build/pbf2json.win32-x64' 'PE32+ executable for MS Windows 6.01 (console), x86-64, 8 sections';
-compress 'build/pbf2json.win32-x64';
+mkdir -p build
+for target in "${targets[@]}"; do
+  build "${target}"
+done


### PR DESCRIPTION
This script had a lot of duplicated code, one section for each arch we built on.

It's pretty easy to remove that duplication, and also add a new feature: passing 'native' as a parameter now limits builds to just the current machine's architecture. This can be helpful in testing scripts to compile just what's needed to run the tests.