### PR TITLE
Set up a pbf2json executable in NPM package path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ pbf2json creates a JSON stream of openstreetmap data from any PBF extract, you c
 
 ![animated-gif](http://missinglink.embed.s3.amazonaws.com/pbf2json-2.gif)
 
+### Install the command-line tool
+
+```bash
+$ npm install -g pbf2json
+$ pbf2json -tags="amenity" /tmp/wellington_new-zealand.osm.pbf
+```
+
+The `pbf2json` command selects the binary matching your platform and passes every argument through to it, so the usage below applies unchanged. It can also be run without installing, using `npx pbf2json ...`.
+
 ### Run from pre-built binary
 
 

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+var os = require('os'),
+    fs = require('fs'),
+    util = require('util'),
+    child = require('child_process'),
+    exec = require('./lib/binaryPath');
+
+if( !fs.existsSync( exec ) ){
+  console.error( util.format(
+    'pbf2json: no binary available for %s-%s, expected: %s',
+    os.platform(), os.arch(), exec
+  ));
+  console.error( 'working from a git clone? run \'npm run compile\' to build it.' );
+  process.exit( 1 );
+}
+
+var proc = child.spawn( exec, process.argv.slice( 2 ), { stdio: 'inherit' });
+
+// propagate signals from parent to child
+process.on( 'SIGINT',  function(){ proc.kill( 'SIGINT' ); });
+process.on( 'SIGTERM', function(){ proc.kill( 'SIGTERM' ); });
+
+proc.on( 'error', function( err ){
+  console.error( util.format( 'pbf2json: failed to run %s:', exec ), err.message );
+  process.exit( 1 );
+});
+
+proc.on( 'exit', function( code, signal ){
+  // mimic the shell convention of reporting a signalled exit as 128+signum
+  process.exit( signal ? 128 + os.constants.signals[signal] : code );
+});

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 
 var util = require('util'),
-    path = require('path'),
-    os = require('os'),
     split = require('split'),
     through = require('through2'),
     child = require('child_process'),
-    exec = path.join(__dirname, 'build', util.format( 'pbf2json.%s-%s', os.platform(), os.arch() ) ),
+    exec = require('./lib/binaryPath'),
     generateParams = require('./lib/generateParams');
 
 // custom log levels can be detected for lines with the format:

--- a/lib/binaryPath.js
+++ b/lib/binaryPath.js
@@ -1,0 +1,12 @@
+
+var util = require('util'),
+    path = require('path'),
+    os = require('os');
+
+// the precompiled binary shipped in ./build for the current platform, note that
+// it may not exist: the npm package ships every target but a git clone only
+// contains whatever ./compile.sh has been run for.
+module.exports = path.join(
+  __dirname, '..', 'build',
+  util.format( 'pbf2json.%s-%s', os.platform(), os.arch() )
+);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "description": "Golang osm pbf parser with npm wrapper",
   "homepage": "https://github.com/pelias/pbf2json",
   "license": "MIT",
+  "main": "index.js",
+  "bin": {
+    "pbf2json": "./cli.js"
+  },
   "scripts": {
     "units": "./bin/units",
     "gotest": "go test ./...",


### PR DESCRIPTION
This simple change instructs NPM to register `pbf2json` as a binary that can be executed, not just used as a library in Node.js code.

It means we can do things like `pbf2json -tags="amenity" /tmp/somepbf.osm.pbf` or even `npx pbf2json -- -tags="amenity" /tmp/somepbf.osm.pbf` to avoid installing the package explicitly.

It doesn't use a symlink to decide on the correct architecture binary to use, instead there's a small Node.js wrapper script.

Closes https://github.com/pelias/pbf2json/issues/66